### PR TITLE
🔧 adjust public app script for secondaryFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ parser.add_argument('-r', '--readme', action='store', dest='readme', help='Readm
 parser.add_argument('-n', '--id-name', action='store', dest='id_name', help='Short app ID link name to use, i.e. kfdrc-align-wf', required=False)
 parser.add_argument('-l', '--label', action='store', dest='label', help='User-friendly label to add to tool/workflow cwl, if needed', required=False)
 parser.add_argument('-t', '--tags', action='store', dest='tags', help='Seven bridges tags file, as csv string, ex RNASEQ,FUSION', required=False)
-parser.add_argument('-f', '--files', action='store', dest='files', help='Cavatica-style tsv manifest with file ID, file name, and associated cwl input key', required=False)
+parser.add_argument('-f', '--files', action='store', dest='files', help='Cavatica-style tsv manifest with file ID, file name, associated cwl input key, and, optionally, secondaryFile name and IDs', required=False)
 parser.add_argument('-p', '--publisher', action='store', dest='pub', help='Publisher name', required=False, default="KFDRC")
 ```
 
@@ -32,7 +32,7 @@ parser.add_argument('-p', '--publisher', action='store', dest='pub', help='Publi
 1. `-n, --id-name`: Short app ID, should be `kfdrc-what-it-do-tool/workflow`
 1. `-l, --label`: User-friendly display name, like `Kids First DRC Alignment Workflow`
 1. `-t, --tags`: Keywords in csv string format that users will be able to search, like `DNA,ALIGNMENT`
-1. `-f, --files`: tsv file manifest with file IDs, file names, and cwl input references. Use `template_files/align_inputs_manifest_APP_PUB.tsv` as an example. If input is an array, just put one per line, usi ng same input key. If order matters, then order them in the correct way
+1. `-f, --files`: tsv file manifest with file IDs, file names, cwl input references, and, optionally, any secondaryFile information. The fields for secondaryFile information also accepts comma-separate lists for files that have multiple secondaryFiles. If your file has no secondaryFiles, you can leave the snames and sfids fields empty or simply write `None`. Use `template_files/align_inputs_manifest_APP_PUB.tsv` as an example. If input is an array, just put one per line, using same input key. If order matters, then order them in the correct way
 1. `-p, --publisher`: simple identifier of center, likely `KFDRC`, unless it;s another center
 
 ### General tips

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ parser.add_argument('-p', '--publisher', action='store', dest='pub', help='Publi
 1. `-n, --id-name`: Short app ID, should be `kfdrc-what-it-do-tool/workflow`
 1. `-l, --label`: User-friendly display name, like `Kids First DRC Alignment Workflow`
 1. `-t, --tags`: Keywords in csv string format that users will be able to search, like `DNA,ALIGNMENT`
-1. `-f, --files`: tsv file manifest with file IDs, file names, cwl input references, and, optionally, any secondaryFile information. The fields for secondaryFile information also accepts comma-separate lists for files that have multiple secondaryFiles. If your file has no secondaryFiles, you can leave the snames and sfids fields empty or simply write `None`. Use `template_files/align_inputs_manifest_APP_PUB.tsv` as an example. If input is an array, just put one per line, using same input key. If order matters, then order them in the correct way
+1. `-f, --files`: tsv file manifest with file IDs, file names, cwl input references, and, optionally, any secondaryFile information. The fields for secondaryFile information also accepts comma-separated lists for files that have multiple secondaryFiles. If your file has no secondaryFiles, you can leave the snames and sfids fields empty or simply write `None`. Use `template_files/align_inputs_manifest_APP_PUB.tsv` as an example. If input is an array, just put one per line, using same input key. If order matters, then order them in the correct way
 1. `-p, --publisher`: simple identifier of center, likely `KFDRC`, unless it;s another center
 
 ### General tips

--- a/cavatica_app_pub.py
+++ b/cavatica_app_pub.py
@@ -11,7 +11,7 @@ parser.add_argument('-r', '--readme', action='store', dest='readme', help='Readm
 parser.add_argument('-n', '--id-name', action='store', dest='id_name', help='Short app ID link name to use, i.e. kfdrc-align-wf', required=False)
 parser.add_argument('-l', '--label', action='store', dest='label', help='User-friendly label to add to tool/workflow cwl, if needed', required=False)
 parser.add_argument('-t', '--tags', action='store', dest='tags', help='Seven bridges tags file, as csv string, ex RNASEQ,FUSION', required=False)
-parser.add_argument('-f', '--files', action='store', dest='files', help='Cavatica-style tsv manifest with file ID, file name, and associated cwl input key', required=False)
+parser.add_argument('-f', '--files', action='store', dest='files', help='Cavatica-style tsv manifest with file ID, file name, associated cwl input key, and, optionally, secondaryFile names and IDs', required=False)
 parser.add_argument('-p', '--publisher', action='store', dest='pub', help='Publisher name', required=False, default="KFDRC")
 args = parser.parse_args()
 

--- a/template_files/gatk_cnv_somatic_pair_APP_PUB.tsv
+++ b/template_files/gatk_cnv_somatic_pair_APP_PUB.tsv
@@ -1,0 +1,4 @@
+id	name	keys	sfids	snames
+60639019357c3a53540ca7e7	Homo_sapiens_assembly38.dict	reference_dict
+60639014357c3a53540ca7a3	Homo_sapiens_assembly38.fasta	reference_fasta	60639016357c3a53540ca7af	Homo_sapiens_assembly38.fasta.fai
+5ea32801e4b0a6d31fa13944	funcotator_dataSources.v1.6.20190124s.tar.gz	funcotator_data_sources_tgz

--- a/template_files/gatk_cnv_somatic_pair_APP_PUB.tsv
+++ b/template_files/gatk_cnv_somatic_pair_APP_PUB.tsv
@@ -1,4 +1,4 @@
 id	name	keys	sfids	snames
 60639019357c3a53540ca7e7	Homo_sapiens_assembly38.dict	reference_dict
 60639014357c3a53540ca7a3	Homo_sapiens_assembly38.fasta	reference_fasta	60639016357c3a53540ca7af	Homo_sapiens_assembly38.fasta.fai
-5ea32801e4b0a6d31fa13944	funcotator_dataSources.v1.6.20190124s.tar.gz	funcotator_data_sources_tgz
+60e5f8636a504e4e0c6408d8	funcotator_dataSources.v1.6.20190124s.tar.gz	funcotator_data_sources_tgz

--- a/template_files/gatk_create_cnv_panel_APP_PUB.tsv
+++ b/template_files/gatk_create_cnv_panel_APP_PUB.tsv
@@ -1,0 +1,3 @@
+id	name	keys	sfids	snames
+60639019357c3a53540ca7e7	Homo_sapiens_assembly38.dict	reference_dict
+60639014357c3a53540ca7a3	Homo_sapiens_assembly38.fasta	reference_fasta	60639016357c3a53540ca7af	Homo_sapiens_assembly38.fasta.fai


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Two things here:
1. adjust the public app script to allow suggested secondaryFiles for each entry
2. added template files for GATK files (the funcotator file still needs to be added to kf-references project)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Used these to make public apps here: https://github.com/kids-first/kf-gatk-cnv-wf/pull/11/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
